### PR TITLE
enhancement/contract-split

### DIFF
--- a/contracts/DNSClaimChecker.sol
+++ b/contracts/DNSClaimChecker.sol
@@ -5,7 +5,7 @@ import "@ensdomains/dnssec-oracle/contracts/BytesUtils.sol";
 import "@ensdomains/dnssec-oracle/contracts/RRUtils.sol";
 import "@ensdomains/buffer/contracts/Buffer.sol";
 
-library ParsingLibrary {
+library DNSClaimChecker {
 
     using BytesUtils for bytes;
     using RRUtils for *;

--- a/contracts/DNSRegistrar.sol
+++ b/contracts/DNSRegistrar.sol
@@ -2,17 +2,13 @@ pragma solidity ^0.4.23;
 
 import "@ensdomains/ens/contracts/ENSRegistry.sol";
 import "@ensdomains/dnssec-oracle/contracts/DNSSEC.sol";
-import "@ensdomains/dnssec-oracle/contracts/BytesUtils.sol";
-import "@ensdomains/dnssec-oracle/contracts/RRUtils.sol";
+import "./ParsingLibrary.sol";
 
 /**
  * @dev An ENS registrar that allows the owner of a DNS name to claim the
  *      corresponding name in ENS.
  */
 contract DNSRegistrar {
-    using BytesUtils for bytes;
-    using RRUtils for *;
-    using Buffer for Buffer.buffer;
 
     uint16 constant CLASS_INET = 1;
     uint16 constant TYPE_TXT = 16;
@@ -37,11 +33,11 @@ contract DNSRegistrar {
      *        record.
      */
     function claim(bytes name, bytes proof) public {
-        address addr = getOwnerAddress(name, proof);
+        address addr = ParsingLibrary.getOwnerAddress(name, proof);
 
         bytes32 labelHash;
         bytes32 rootNode;
-        (labelHash, rootNode) = getLabels(name);
+        (labelHash, rootNode) = ParsingLibrary.getLabels(name);
         
         ens.setSubnodeOwner(rootNode, labelHash, addr);
         emit Claim(keccak256(abi.encodePacked(rootNode, labelHash)), addr, name);
@@ -57,77 +53,5 @@ contract DNSRegistrar {
     function proveAndClaim(bytes name, bytes input, bytes proof) public {
         proof = oracle.submitRRSets(input, proof);
         claim(name, proof);
-    }
-
-    function getLabels(bytes memory name) internal view returns (bytes32, bytes32) {
-        uint len = name.readUint8(0);
-        uint second = name.readUint8(len + 1);
-
-        require(name.readUint8(len + second + 2) == 0);
-
-        return (name.keccak(1, len), keccak256(bytes32(0), name.keccak(2 + len, second)));
-    }
-
-    function getOwnerAddress(bytes memory name, bytes memory proof) internal view returns(address) {
-        // Add "_ens." to the front of the name.
-        Buffer.buffer memory buf;
-        buf.init(name.length + 5);
-        buf.append("\x04_ens");
-        buf.append(name);
-        bytes20 hash;
-        uint64 inserted;
-        // Check the provided TXT record has been validated by the oracle
-        (, inserted, hash) = oracle.rrdata(TYPE_TXT, buf.buf);
-        if(hash == bytes20(0) && proof.length == 0) return 0;
-
-        require(hash == bytes20(keccak256(proof)));
-
-        for(RRUtils.RRIterator memory iter = proof.iterateRRs(0); !iter.done(); iter.next()) {
-            require(inserted + iter.ttl >= now, "DNS record is stale; refresh or delete it before proceeding.");
-
-            address addr = parseRR(proof, iter.rdataOffset);
-            if(addr != 0) {
-                return addr;
-            }
-        }
-
-        return 0;
-    }
-
-    function parseRR(bytes memory rdata, uint idx) internal pure returns(address) {
-        while(idx < rdata.length) {
-            uint len = rdata.readUint8(idx); idx += 1;
-            address addr = parseString(rdata, idx, len);
-            if(addr != 0) return addr;
-            idx += len;
-        }
-
-        return 0;
-    }
-
-    function parseString(bytes memory str, uint idx, uint len) internal pure returns(address) {
-        // TODO: More robust parsing that handles whitespace and multiple key/value pairs
-        if(str.readUint32(idx) != 0x613d3078) return 0; // 0x613d3078 == 'a=0x'
-        if(len < 44) return 0;
-        return hexToAddress(str, idx + 4);
-    }
-
-    function hexToAddress(bytes memory str, uint idx) internal pure returns(address) {
-        if(str.length - idx < 40) return 0;
-        uint ret = 0;
-        for(uint i = idx; i < idx + 40; i++) {
-            ret <<= 4;
-            uint x = str.readUint8(i);
-            if(x >= 48 && x < 58) {
-                ret |= x - 48;
-            } else if(x >= 65 && x < 71) {
-                ret |= x - 55;
-            } else if(x >= 97 && x < 103) {
-                ret |= x - 87;
-            } else {
-                return 0;
-            }
-        }
-        return address(ret);
     }
 }

--- a/contracts/DNSRegistrar.sol
+++ b/contracts/DNSRegistrar.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.4.23;
 
 import "@ensdomains/ens/contracts/ENSRegistry.sol";
 import "@ensdomains/dnssec-oracle/contracts/DNSSEC.sol";
-import "./ParsingLibrary.sol";
+import "./DNSClaimChecker.sol";
 
 /**
  * @dev An ENS registrar that allows the owner of a DNS name to claim the
@@ -30,11 +30,11 @@ contract DNSRegistrar {
      *        record.
      */
     function claim(bytes name, bytes proof) public {
-        address addr = ParsingLibrary.getOwnerAddress(oracle, name, proof);
+        address addr = DNSClaimChecker.getOwnerAddress(oracle, name, proof);
 
         bytes32 labelHash;
         bytes32 rootNode;
-        (labelHash, rootNode) = ParsingLibrary.getLabels(name);
+        (labelHash, rootNode) = DNSClaimChecker.getLabels(name);
         
         ens.setSubnodeOwner(rootNode, labelHash, addr);
         emit Claim(keccak256(abi.encodePacked(rootNode, labelHash)), addr, name);

--- a/contracts/DNSRegistrar.sol
+++ b/contracts/DNSRegistrar.sol
@@ -10,9 +10,6 @@ import "./ParsingLibrary.sol";
  */
 contract DNSRegistrar {
 
-    uint16 constant CLASS_INET = 1;
-    uint16 constant TYPE_TXT = 16;
-
     DNSSEC public oracle;
     ENS public ens;
 
@@ -33,7 +30,7 @@ contract DNSRegistrar {
      *        record.
      */
     function claim(bytes name, bytes proof) public {
-        address addr = ParsingLibrary.getOwnerAddress(name, proof);
+        address addr = ParsingLibrary.getOwnerAddress(oracle, name, proof);
 
         bytes32 labelHash;
         bytes32 rootNode;

--- a/contracts/ParsingLibrary.sol
+++ b/contracts/ParsingLibrary.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.4.24;
 
+import "@ensdomains/dnssec-oracle/contracts/DNSSEC.sol";
 import "@ensdomains/dnssec-oracle/contracts/BytesUtils.sol";
 import "@ensdomains/dnssec-oracle/contracts/RRUtils.sol";
 import "@ensdomains/buffer/contracts/Buffer.sol";
@@ -10,6 +11,9 @@ library ParsingLibrary {
     using RRUtils for *;
     using Buffer for Buffer.buffer;
 
+    uint16 constant CLASS_INET = 1;
+    uint16 constant TYPE_TXT = 16;
+
     function getLabels(bytes memory name) internal view returns (bytes32, bytes32) {
         uint len = name.readUint8(0);
         uint second = name.readUint8(len + 1);
@@ -19,7 +23,7 @@ library ParsingLibrary {
         return (name.keccak(1, len), keccak256(bytes32(0), name.keccak(2 + len, second)));
     }
 
-    function getOwnerAddress(bytes memory name, bytes memory proof) internal view returns (address) {
+    function getOwnerAddress(DNSSEC oracle, bytes memory name, bytes memory proof) internal view returns (address) {
         // Add "_ens." to the front of the name.
         Buffer.buffer memory buf;
         buf.init(name.length + 5);

--- a/contracts/ParsingLibrary.sol
+++ b/contracts/ParsingLibrary.sol
@@ -1,0 +1,85 @@
+pragma solidity ^0.4.24;
+
+import "@ensdomains/dnssec-oracle/contracts/BytesUtils.sol";
+import "@ensdomains/dnssec-oracle/contracts/RRUtils.sol";
+import "@ensdomains/buffer/contracts/Buffer.sol";
+
+library ParsingLibrary {
+
+    using BytesUtils for bytes;
+    using RRUtils for *;
+    using Buffer for Buffer.buffer;
+
+    function getLabels(bytes memory name) internal view returns (bytes32, bytes32) {
+        uint len = name.readUint8(0);
+        uint second = name.readUint8(len + 1);
+
+        require(name.readUint8(len + second + 2) == 0);
+
+        return (name.keccak(1, len), keccak256(bytes32(0), name.keccak(2 + len, second)));
+    }
+
+    function getOwnerAddress(bytes memory name, bytes memory proof) internal view returns (address) {
+        // Add "_ens." to the front of the name.
+        Buffer.buffer memory buf;
+        buf.init(name.length + 5);
+        buf.append("\x04_ens");
+        buf.append(name);
+        bytes20 hash;
+        uint64 inserted;
+        // Check the provided TXT record has been validated by the oracle
+        (, inserted, hash) = oracle.rrdata(TYPE_TXT, buf.buf);
+        if (hash == bytes20(0) && proof.length == 0) return 0;
+
+        require(hash == bytes20(keccak256(proof)));
+
+        for (RRUtils.RRIterator memory iter = proof.iterateRRs(0); !iter.done(); iter.next()) {
+            require(inserted + iter.ttl >= now, "DNS record is stale; refresh or delete it before proceeding.");
+
+            address addr = parseRR(proof, iter.rdataOffset);
+            if (addr != 0) {
+                return addr;
+            }
+        }
+
+        return 0;
+    }
+
+    function parseRR(bytes memory rdata, uint idx) internal pure returns (address) {
+        while (idx < rdata.length) {
+            uint len = rdata.readUint8(idx); idx += 1;
+            address addr = parseString(rdata, idx, len);
+            if (addr != 0) return addr;
+            idx += len;
+        }
+
+        return 0;
+    }
+
+    function parseString(bytes memory str, uint idx, uint len) internal pure returns (address) {
+        // TODO: More robust parsing that handles whitespace and multiple key/value pairs
+        if (str.readUint32(idx) != 0x613d3078) return 0; // 0x613d3078 == 'a=0x'
+        if (len < 44) return 0;
+        return hexToAddress(str, idx + 4);
+    }
+
+    function hexToAddress(bytes memory str, uint idx) internal pure returns (address) {
+        if (str.length - idx < 40) return 0;
+        uint ret = 0;
+        for (uint i = idx; i < idx + 40; i++) {
+            ret <<= 4;
+            uint x = str.readUint8(i);
+            if (x >= 48 && x < 58) {
+                ret |= x - 48;
+            } else if (x >= 65 && x < 71) {
+                ret |= x - 55;
+            } else if (x >= 97 && x < 103) {
+                ret |= x - 87;
+            } else {
+                return 0;
+            }
+        }
+        return address(ret);
+    }
+
+}

--- a/truffle.js
+++ b/truffle.js
@@ -1,9 +1,9 @@
 module.exports = {
-  mocha: {
-    reporter: 'eth-gas-reporter',
-    reporterOptions : {
-      currency: 'USD',
-      gasPrice: 1
-    }
-  }
+  // mocha: {
+  //   reporter: 'eth-gas-reporter',
+  //   reporterOptions : {
+  //     currency: 'USD',
+  //     gasPrice: 1
+  //   }
+  // }
 };


### PR DESCRIPTION
This pull request moves the parsing functions into a separate `library`.

**Why?**

Due to the fact there are multiple repositories now using those functions such as `optimistic-dnssec` as well as `root` it makes sense to make this logic reusable without needing to inherit the entire `DNSRegistrar` contract.